### PR TITLE
Disable warnings from size method on mashie objects. 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,10 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 2.7
           - 3.0
           - 3.1
           - 3.2
-
+          - 3.3
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,8 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 2.7
-          - 3.2
+          - 3.0
+          - 3.3
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/lib/api_struct/entity.rb
+++ b/lib/api_struct/entity.rb
@@ -28,7 +28,7 @@ module ApiStruct
       def entity?(attr, options)
         entity_attributes << attr.to_sym
         define_method attr.to_s do
-          return unless entity[attr]
+          return false unless entity[attr]
           self.class.convert_to_entity(entity[attr], options[:as])
         end
       end

--- a/lib/api_struct/entity.rb
+++ b/lib/api_struct/entity.rb
@@ -60,10 +60,14 @@ module ApiStruct
 
     attr_reader :entity, :entity_status
 
+    class EntityMash < Hashie::Mash
+      disable_warnings :size
+    end
+
     # rubocop:disable Style/OptionalBooleanParameter
     def initialize(entity, entity_status = true)
       raise EntityError, "#{entity} must be Hash" unless entity.is_a?(Hash)
-      @entity = Hashie::Mash.new(extract_attributes(entity))
+      @entity = EntityMash.new(extract_attributes(entity))
       @entity_status = entity_status
       __setobj__(@entity)
     end


### PR DESCRIPTION
## Description
- Ref https://github.com/hashie/hashie/issues/423
- Disable warnings from size method on mashie objects. 
- This is something that most API reseponse will contain as a key

## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
